### PR TITLE
Readme typo for document.getElementsById

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -84,7 +84,7 @@ Currently, Hyper SDK supports below authentication modes:
 > </div>
 > <script>
 >   document
->     .getElementsById('hyper-sdk-login')
+>     .getElementById('hyper-sdk-login')
 >     .addEventListener('click', function () {
 >       var username = document.getElementById('username').value;
 >       var password = document.getElementById('password').value;


### PR DESCRIPTION
Change "document.getElementsById" to => "document.getElementById" otherwise a type error will occur, "Uncaught TypeError: document.getElementsById is not a function". Also ids should be unique hence only one element for each id.