### PR TITLE
DE265540:Update URL to Authentication mode page

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -67,7 +67,7 @@ Currently, Hyper SDK supports below authentication modes:
 * Standard (*see the note below*)
 * SAML
 
-*Read more about [authentication mode](https://www2.microstrategy.com/producthelp/2019/Library/en-us/Content/Modes_of_authentication.htm)*.
+*Read more about [authentication mode](https://www2.microstrategy.com/producthelp/Current/SystemAdmin/WebHelp/Lang_1033/Content/Modes_of_authentication.htm)*.
 
 > **NOTE**
 >


### PR DESCRIPTION
The authentication mode link is broken https://microstrategy.github.io/hyper-sdk/config/#authentication-configurations

![image](https://github.com/MicroStrategy/hyper-sdk/assets/97595156/a215e066-45f6-482d-9f56-732d13873176)
